### PR TITLE
feat: auto-hint after wrong moves and agent browser rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,3 +24,8 @@
 - Always verify UI/UX changes by running a browser and testing the new feature
 - Always use tdd: write one failing test, make it pass, refactor, repeat
 - Always add regression tests
+
+# Browser automation (IDE browser MCP)
+
+- Do not take browser screenshots unless the user explicitly asks for a screenshot in their message
+- Never use `browser_mouse_click_xy`; interact using element refs from snapshots (or other ref-based browser tools) instead

--- a/app/composables/useSessionFlow.ts
+++ b/app/composables/useSessionFlow.ts
@@ -9,6 +9,14 @@ import type { Line } from '~/domain/types'
 
 type BoardRef = Ref<InstanceType<typeof ChessBoardComponent> | null>
 
+/**
+ * Delay between an illegal user attempt and undoing it on the board. Long
+ * enough for the user to see what they tried, short enough that the auto-hint
+ * arrow feels like immediate feedback. Centralised here so the value can stay
+ * in sync with QA timing (§4.4.1) and unit tests.
+ */
+export const WRONG_MOVE_UNDO_DELAY_MS = 200
+
 interface UseSessionFlowArgs {
   session: Ref<TrainingSession | null>
   currentLine: Ref<Line | null>
@@ -42,6 +50,13 @@ export interface UseSessionFlow {
   bufferUserMove: (san: string) => void
   /** Take and clear any buffered premove. */
   flushBufferedUserMove: () => string | null
+  /**
+   * Single-try wrong-move feedback: lock the board, undo the illegal try after
+   * a short pause, draw the expected-move hint arrow, and unlock. Replaces the
+   * page-level inline timer so the hint is shown automatically on every
+   * mistake (no need for the user to press Hilfe).
+   */
+  handleWrongMove: () => void
 }
 
 /**
@@ -253,6 +268,15 @@ export const useSessionFlow = ({
     setBoardLocked(false)
   }
 
+  const handleWrongMove = (): void => {
+    setBoardLocked(true)
+    setTimeout(() => {
+      board.value?.undoLastMove()
+      showHintForExpected()
+      setBoardLocked(false)
+    }, WRONG_MOVE_UNDO_DELAY_MS)
+  }
+
   const isOpponentInFlight = (): boolean => opponentInFlight
 
   const bufferUserMove = (san: string): void => {
@@ -280,5 +304,6 @@ export const useSessionFlow = ({
     isOpponentInFlight,
     bufferUserMove,
     flushBufferedUserMove,
+    handleWrongMove,
   }
 }

--- a/app/pages/learn/play.vue
+++ b/app/pages/learn/play.vue
@@ -214,11 +214,7 @@ const processUserMove = async (san: string): Promise<void> => {
   const result = await s.submit(san)
 
   if (result.result === 'wrong') {
-    flow.setBoardLocked(true)
-    setTimeout(() => {
-      board.value?.undoLastMove()
-      flow.setBoardLocked(false)
-    }, 200)
+    flow.handleWrongMove()
     return
   }
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -166,7 +166,7 @@ Short sessions on phone; bottom navigation; leaves mid-line.
 - **D10.** **Intro:** User plays prefix to reach line start when applicable; banner can prompt playing parent opening until **Grundposition**; **Hab ich vergessen** link can jump user to parent reminder flow when parent exists.
 - **D11.** **Building (training):** Stepwise walk through user-relevant plies; hints on **new** steps until demonstrated.
 - **D12.** **Repeating:** Fixed target repetition count (**5** reps in domain) with **full board resets** between reps; banner copy and precedence are specified in **§4.4.1**.
-- **D13.** **Wrong move:** single-try feedback (undo + mistake banner), **not** a full-line reset; details and timings in **§4.4.1**.
+- **D13.** **Wrong move:** single-try feedback (undo + auto-drawn hint arrow for the expected move), **not** a full-line reset; details and timings in **§4.4.1**.
 
 **Requirements — bottom action bar**
 
@@ -193,18 +193,19 @@ This subsection is the **authoritative UX spec** for the drill screen (implement
 
 - **One contextual banner** above the board in a **fixed-height** strip so the board does not jump when copy wraps.
 - Banners use **`role="status"`** and **`aria-live="polite"`** when shown.
-- Each **banner kind** has a distinct color + icon in the UI (`hint`, `memory`, `setup-complete`, `motivation`, `mistake`).
+- Each **banner kind** has a distinct color + icon in the UI (`hint`, `memory`, `setup-complete`, `motivation`).
 
 **Ephemeral vs persistent banners**
 
-- **Ephemeral** (`hint`, `mistake`): cleared on the next **correct** user move (or when superseded); they must not hide the meaning of longer-lived banners incorrectly—see code path `clearEphemeralBanner`.
+- **Ephemeral** (`hint`): cleared on the next **correct** user move (or when superseded); they must not hide the meaning of longer-lived banners incorrectly—see code path `clearEphemeralBanner`.
 - **Persistent through subsequent moves** (`memory`, `setup-complete`, `motivation`): stay visible until the next reset or clearing logic in the flow; the user should still see “play from memory” context while replaying plies.
 
 **Wrong move (error feedback)—not a full line reset**
 
-- On wrong SAN: show **`mistake`** banner with copy **`Falscher Zug – nochmal versuchen`** (`MISTAKE_BANNER_TEXT`).
-- Board: **brief lock**, **undo the illegal try** after ~200 ms, then unlock; **no** `getResetReason` transition and **no** prefix replay for a simple wrong guess.
-- Mistake banner **auto-clears** after **1800 ms** if still showing.
+- Board: **brief lock**, **undo the illegal try** after `WRONG_MOVE_UNDO_DELAY_MS` (200 ms), **auto-draw the expected-move hint arrow** (same arrow as the **Hilfe** button), then unlock; **no** `getResetReason` transition and **no** prefix replay for a simple wrong guess.
+- The auto-hint is implementation-equivalent to pressing **Hilfe** (`showHintForExpected`) but is **not** counted as a `help_requested` activity event — only the `mistake` event is recorded, so analytics still distinguishes mistakes from voluntary help.
+- The hint arrow follows the standard ephemeral lifecycle: it is cleared on the next correct user move, on board interaction, or when superseded.
+- Earlier revisions of this section described a `mistake` text banner (`Falscher Zug – nochmal versuchen`) above the board. That banner has been **replaced** by the auto-drawn hint arrow as the wrong-move feedback surface, because seeing the correct square is more actionable than reading a generic error string.
 
 **When the full board resets** (physical reset + prefix replay + opponent chain)
 
@@ -246,7 +247,7 @@ Historical / optional: `next-step` was previously tied to a physical reset and a
 | Opponent auto-move delay | 350 ms | Pause before the app plays the opponent’s SAN. |
 | Delay before board reset after boundary | 600 ms | Beat between last move and animated return to parent base. |
 | Delay before advancing to **next line** after mastery | 1500 ms | Breathing room before new line session. |
-| Mistake banner visible | 1800 ms | Auto-dismiss mistake feedback. |
+| Wrong-move undo + auto-hint (`WRONG_MOVE_UNDO_DELAY_MS`) | 200 ms | Brief pause so the user sees their illegal try before it is undone and the expected-move arrow is drawn. |
 | Parent base after physical reset | ~220 ms (animated) | One Chessground transition from the current mess to the correct parent-prefix FEN (not via global start plus a second jump). Rare invalid data: fall back to global reset plus instant prefix replay. |
 
 **Premove / lock interaction with reset**

--- a/tests/unit/composables/useSessionFlow.spec.ts
+++ b/tests/unit/composables/useSessionFlow.spec.ts
@@ -22,6 +22,7 @@ const buildBoardStub = () => {
   const reset = vi.fn()
   const setPositionFromFen = vi.fn()
   const setMoveAnimationEnabled = vi.fn()
+  const undoLastMove = vi.fn()
   const board = shallowRef({
     setLocked,
     drawHintForSan,
@@ -30,6 +31,7 @@ const buildBoardStub = () => {
     reset,
     setPositionFromFen,
     setMoveAnimationEnabled,
+    undoLastMove,
   } as unknown as InstanceType<typeof import('~/components/ChessBoard.vue')['default']>)
   return {
     board,
@@ -40,6 +42,7 @@ const buildBoardStub = () => {
     reset,
     setPositionFromFen,
     setMoveAnimationEnabled,
+    undoLastMove,
   }
 }
 
@@ -256,6 +259,67 @@ describe('useSessionFlow', () => {
       fenAfterFirstNSans(line.sanMoves, 2),
     )
     expect(playOpponentSan).not.toHaveBeenCalled()
+  })
+
+  it('handleWrongMove undoes the last move and auto-shows the expected hint', async () => {
+    vi.useFakeTimers()
+    try {
+      const { board, setLocked, undoLastMove, drawHintForSan } = buildBoardStub()
+      const flowLocked = ref(false)
+      const flow = useSessionFlow({
+        session: shallowRef(buildSession({ expectedSan: 'Bc4' })),
+        currentLine: ref(buildLine(['e4'])),
+        demonstratedSteps: ref(new Set()),
+        board,
+        flowLocked,
+        isReplayMode: computed(() => false),
+        resetReplayView: () => {},
+      })
+
+      flow.handleWrongMove()
+      expect(flowLocked.value).toBe(true)
+      expect(setLocked).toHaveBeenLastCalledWith(true)
+      expect(undoLastMove).not.toHaveBeenCalled()
+      expect(drawHintForSan).not.toHaveBeenCalled()
+
+      await vi.runAllTimersAsync()
+
+      expect(undoLastMove).toHaveBeenCalledTimes(1)
+      expect(drawHintForSan).toHaveBeenCalledWith('Bc4')
+      expect(flow.hintActive.value).toBe(true)
+      expect(flowLocked.value).toBe(false)
+      expect(setLocked).toHaveBeenLastCalledWith(false)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('handleWrongMove still unlocks the board when no hint can be drawn', async () => {
+    vi.useFakeTimers()
+    try {
+      const { board, setLocked, undoLastMove, drawHintForSan } = buildBoardStub()
+      const flowLocked = ref(false)
+      const flow = useSessionFlow({
+        session: shallowRef(buildSession({ expectedSan: null })),
+        currentLine: ref(buildLine(['e4'])),
+        demonstratedSteps: ref(new Set()),
+        board,
+        flowLocked,
+        isReplayMode: computed(() => false),
+        resetReplayView: () => {},
+      })
+
+      flow.handleWrongMove()
+      await vi.runAllTimersAsync()
+
+      expect(undoLastMove).toHaveBeenCalledTimes(1)
+      expect(drawHintForSan).not.toHaveBeenCalled()
+      expect(flow.hintActive.value).toBe(false)
+      expect(flowLocked.value).toBe(false)
+      expect(setLocked).toHaveBeenLastCalledWith(false)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('isOpponentInFlight is false at rest', () => {


### PR DESCRIPTION
## Summary

- Centralize wrong-move handling in `useSessionFlow` with `handleWrongMove`: briefly lock the board, undo the illegal try after `WRONG_MOVE_UNDO_DELAY_MS` (200 ms), draw the expected-move hint arrow (`showHintForExpected`), then unlock.
- Wire `learn/play` wrong-move path to the composable instead of an inline timeout.
- Update `docs/prd.md` so wrong-move UX is defined as undo + auto-hint arrow (replacing the old mistake text banner) and adjust the timing table accordingly.
- Add unit coverage for `handleWrongMove` in `useSessionFlow.spec.ts`.
- Extend `AGENTS.md` with IDE browser MCP rules: no screenshots unless the user explicitly asks; never use `browser_mouse_click_xy`—use snapshot refs or other ref-based tools.

## Test plan

- [ ] `pnpm test` (or at least `pnpm vitest run tests/unit/composables/useSessionFlow.spec.ts`)
- [ ] Manual: in Learn → Play, play an incorrect move; confirm brief lock, undo, and expected-move arrow without needing **Hilfe**
- [ ] Manual: correct follow-up move clears hint / behaves as before