### PR TITLE
Remove Playwright last-run file from repo

### DIFF
--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "passed",
-  "failedTests": []
-}


### PR DESCRIPTION
## Summary

- Stop tracking `test-results/.last-run.json`, a generated Playwright artifact that should not live in version control.

## Test plan

- [ ] Confirm CI / local Playwright still writes `test-results/` as expected when tests run.
- [ ] Verify `.gitignore` (if present) continues to ignore `test-results/` so this file is not re-added accidentally.