### PR TITLE
Fix unknown openings topic empty state (F4)

### DIFF
--- a/app/composables/useTopic.ts
+++ b/app/composables/useTopic.ts
@@ -1,5 +1,6 @@
 import { ref, watch, type Ref } from 'vue'
 import type { Topic } from '~/domain/types'
+import { isTopicNotFoundError } from '~/infra/topic-not-found-error'
 
 interface UseTopicState {
   topic: Ref<Topic | null>
@@ -22,7 +23,11 @@ export const useTopic = (idRef: Ref<string | null | undefined>): UseTopicState =
       topic.value = t
       return t
     } catch (err) {
-      error.value = err as Error
+      if (isTopicNotFoundError(err)) {
+        error.value = null
+      } else {
+        error.value = err as Error
+      }
       topic.value = null
       throw err
     } finally {

--- a/app/infra/openings-loader.ts
+++ b/app/infra/openings-loader.ts
@@ -1,5 +1,6 @@
 import { treeFileToFamily } from '~/domain/data/family-tree-file'
 import type { Topic } from '~/domain/types'
+import { TopicNotFoundError } from '~/infra/topic-not-found-error'
 import type { OpeningsIndex, TopicIndexFile } from '~/domain/data/split-dataset'
 
 export interface OpeningsLoader {
@@ -8,6 +9,20 @@ export interface OpeningsLoader {
 }
 
 const stripTrailingSlash = (url: string): string => url.replace(/\/+$/, '')
+
+/** Static hosts often answer unknown `*.json` paths with SPA `index.html` (200 OK). Treat as missing topic. */
+const readTopicShellJson = async (topicId: string, res: Response): Promise<TopicIndexFile> => {
+  const text = await res.text()
+  const trimmed = text.trimStart()
+  if (trimmed.startsWith('<')) {
+    throw new TopicNotFoundError(topicId)
+  }
+  try {
+    return JSON.parse(text) as TopicIndexFile
+  } catch {
+    throw new Error(`Failed to parse topic index for '${topicId}'`)
+  }
+}
 
 export const createHttpOpeningsLoader = (
   baseUrl: string,
@@ -54,11 +69,14 @@ export const createHttpOpeningsLoader = (
     const promise = (async () => {
       const shellRes = await fetchImpl(topicIndexUrl(id))
       if (!shellRes.ok) {
+        if (shellRes.status === 404) {
+          throw new TopicNotFoundError(id)
+        }
         throw new Error(
           `Failed to load topic '${id}': ${shellRes.status} ${shellRes.statusText}`,
         )
       }
-      const shell = (await shellRes.json()) as TopicIndexFile
+      const shell = await readTopicShellJson(id, shellRes)
       const families = await Promise.all(
         shell.families.map(async (row) => {
           const res = await fetchImpl(familyUrl(id, row.id))

--- a/app/infra/topic-not-found-error.ts
+++ b/app/infra/topic-not-found-error.ts
@@ -1,0 +1,12 @@
+export class TopicNotFoundError extends Error {
+  readonly topicId: string
+
+  constructor(topicId: string) {
+    super(`Topic not found: ${topicId}`)
+    this.name = 'TopicNotFoundError'
+    this.topicId = topicId
+  }
+}
+
+export const isTopicNotFoundError = (err: unknown): err is TopicNotFoundError =>
+  err instanceof TopicNotFoundError

--- a/tests/e2e/journey-f-edge-storage-routes.spec.ts
+++ b/tests/e2e/journey-f-edge-storage-routes.spec.ts
@@ -36,12 +36,9 @@ test('F3 corrupt progress does not crash app', async ({ page }) => {
 test('F4 unknown topic shows German warning', async ({ page }) => {
   await page.goto('/openings/not-a-real-topic-id')
   await page.waitForLoadState('load')
-  await page
-    .getByText(/Unbekanntes Thema|not valid JSON|Unexpected token/)
-    .waitFor({ state: 'visible' })
-  await expect(
-    page.getByText(/Unbekanntes Thema|not valid JSON|Unexpected token/),
-  ).toBeVisible({ timeout: E2E_MAX_WAIT_MS })
+  await expect(page.getByText(/Unbekanntes Thema/)).toBeVisible({
+    timeout: E2E_MAX_WAIT_MS,
+  })
 })
 
 test('F1 refresh mid-session keeps play usable', async ({ familyTree, learnPlay, page }) => {

--- a/tests/unit/infra/openings-loader.spec.ts
+++ b/tests/unit/infra/openings-loader.spec.ts
@@ -60,10 +60,12 @@ const makeFetch = (responses: Record<string, unknown>) =>
     if (body === undefined) {
       return { ok: false, status: 404, statusText: 'Not Found' } as Response
     }
+    const bodyJson = (): string => JSON.stringify(body)
     return {
       ok: true,
       status: 200,
       json: async () => body,
+      text: bodyJson,
     } as unknown as Response
   })
 
@@ -135,13 +137,42 @@ describe('createHttpOpeningsLoader', () => {
     expect(fetchImpl).toHaveBeenCalledTimes(2)
   })
 
-  it('throws a useful error when the topic is missing', async () => {
+  it('throws TopicNotFoundError when the topic shell is missing', async () => {
     const fetchImpl = makeFetch({})
     const loader = createHttpOpeningsLoader(
       'https://example.test/data/openings',
       fetchImpl as unknown as typeof fetch,
     )
-    await expect(loader.loadTopic('missing')).rejects.toThrow(/missing/)
+    await expect(loader.loadTopic('missing')).rejects.toMatchObject({
+      name: 'TopicNotFoundError',
+      topicId: 'missing',
+    })
+  })
+
+  it('maps SPA HTML fallback (200 + HTML document) on topic shell URL to TopicNotFoundError', async () => {
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url.endsWith('/ghost-topic/index.json')) {
+        return {
+          ok: true,
+          status: 200,
+          text: async () =>
+            `<!DOCTYPE html><html lang="en"><body><div id="__nuxt"></div></body></html>`,
+        } as Response
+      }
+      return {
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      } as Response
+    }) as unknown as typeof fetch
+    const loader = createHttpOpeningsLoader(
+      'https://example.test/data/openings',
+      fetchImpl,
+    )
+    await expect(loader.loadTopic('ghost-topic')).rejects.toMatchObject({
+      name: 'TopicNotFoundError',
+      topicId: 'ghost-topic',
+    })
   })
 
   it('deduplicates inflight requests for the same topic', async () => {
@@ -159,6 +190,7 @@ describe('createHttpOpeningsLoader', () => {
           ok: true,
           status: 200,
           json: () => shellReady,
+          text: async () => JSON.stringify(await shellReady),
         } as unknown as Response
       }
       if (url.includes('/e4/families/italian-game.json')) {
@@ -166,6 +198,7 @@ describe('createHttpOpeningsLoader', () => {
           ok: true,
           status: 200,
           json: () => familyReady,
+          text: async () => JSON.stringify(await familyReady),
         } as unknown as Response
       }
       return { ok: false, status: 404, statusText: 'Not Found' } as Response


### PR DESCRIPTION
## Summary

- Throw `TopicNotFoundError` when a topic shell JSON is missing (`404`) or when static hosting returns SPA HTML instead of JSON (`200` + `<`).
- In `useTopic`, treat that case as an expected miss so the topic page shows the German `UAlert` instead of `BaseErrorAlert` with a JSON parse error.
- Tighten Journey F e2e to assert the localized copy and extend unit tests for the loader.

## Test plan

- [ ] `pnpm test -- tests/unit/infra/openings-loader.spec.ts`
- [ ] `pnpm test:e2e -- tests/e2e/journey-f-edge-storage-routes.spec.ts -g "F4"`